### PR TITLE
Text-align center day abbreviations

### DIFF
--- a/lib/simplepicker.css
+++ b/lib/simplepicker.css
@@ -123,6 +123,7 @@
   padding-bottom: 6px;
   width: 14.28%;
   height: 30px;
+  text-align: center;
 }
 
 .simplepicker-calender tbody td {


### PR DESCRIPTION
I am using simplepicker at work in a Bootstrap 4-powered site, and their CSS reset stylesheet resets the browser default `text-align: center` on `<th>`  elements, which messes up the picker's appearance. All this PR does is add an explicit `text-align: center` on the `th` selector for day abbreviations so the appearance remains the same. A case could be made against this, but I'm of the thought that if I'm importing a library, it keeps an consistent appearance at all times. So visually, this change changes nothing but makes the design a little more bullet-proof.

Thank you for making this, BTW! I've been looking for a nice, jQuery/dependency-free datetime picker for a while and this is exactly what I've wanted. 😃 